### PR TITLE
FEAT/dns connect

### DIFF
--- a/django_project/.config/nginx/django_project.conf
+++ b/django_project/.config/nginx/django_project.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name *.compute.amazonaws.com;
+    server_name * .compute.amazonaws.com * .corini.site;
     charset utf-8;
     client_max_body_size 128M;
  


### PR DESCRIPTION
1. dns 가비아에서 하나 샀습니다.
2. -----> 'corini.site'
3. aws 에서 탄력적 IP 할당 받아서 dns 연결했습니다. 
4. aws 내의 settings.py 에서 ALLOWED_HOSTS 에 ".corini.site" 를 추가했습니다.
5. 'django_project.conf' 파일 내의 server_name 에 .corini.site 를 추가했습니다.


* 이제 aws 인스턴스를 시작하고 'corini.site'를 입력하면 우리의 페이지에 접속할 수 있습니다.